### PR TITLE
Update create_trajectories_kml.R

### DIFF
--- a/R/create_trajectories_kml.R
+++ b/R/create_trajectories_kml.R
@@ -45,7 +45,7 @@ create_trajectories_kml <- function(lons, lats, timestamps, id_codes, t0, tf, ou
   }
 
   #get time indexes
-  tidxs <- seq(t0,tf,step)
+  tidxs <- seq(which(timestamps==t0), which(timestamps==tf), step)
 
   # START WRITING
   sink(output_file_path)


### PR DESCRIPTION
This line caused errors for me in the later "for (tt in tidxs)" loops. The timestamps get converted to numeric in the loop, causing it to throw an "out of bonds" error. This is a simple proposed change that fixed it for me. This actually gets the indeces instead of the timestamps.