### PR TITLE
gspdt review

### DIFF
--- a/R/get_spatially_discretized_trajectories.R
+++ b/R/get_spatially_discretized_trajectories.R
@@ -34,7 +34,7 @@ get_spatially_discretized_trajectories <- function(xs, ys, R, breaks = NULL, ver
   checkmate::assert_matrix(ys, mode = 'numeric', nrows = nrow(xs), ncol=ncol(xs))
   checkmate::assert_number(R, lower=0)
   checkmate::check_integerish(
-    breaks, lower=1, upper=ncol(xs), min.len = 1, max.len = ncol(xs), unique = TRUE, null.ok=TRUE
+    breaks, lower=1, upper=ncol(xs), min.len = 1, max.len = ncol(xs), unique = TRUE, sorted=TRUE, null.ok=TRUE
   )
   checkmate::check_flag(verbose)
 
@@ -46,6 +46,11 @@ get_spatially_discretized_trajectories <- function(xs, ys, R, breaks = NULL, ver
   #set breaks, if not yet set
   if(is.null(breaks)){
     breaks <- c(1, n_times + 1)
+  }
+
+  #add start point to breaks if needed
+  if(breaks[1] != 1){
+    breaks <- c(1, breaks)
   }
 
   #add end point to breaks if needed

--- a/R/get_spatially_discretized_trajectories.R
+++ b/R/get_spatially_discretized_trajectories.R
@@ -1,7 +1,7 @@
 #'Get spatially discretized trajectories
 #'
 #' @description
-#' `r lifecycle::badge("experimental")`
+#' `r lifecycle::badge("stable")`
 #'
 #' Gets spatially discretized trajectories from temporally discretized trajectories
 #' by breaking down the trajectory into steps of minimum length `R`. 
@@ -12,7 +12,7 @@
 #' TODO: Code doesn't deal well with strings of NAs within it - look into this.
 #'
 #' @author Ariana Strandburg-Peshkin (primary author)
-#' @author NOT YET CODE REVIEWED
+#' @author Brock (reviewer)
 #'
 #' @param xs `N x n_times` matrix giving x coordinates of each individual over time
 #' @param ys `N x n_times` matrix giving y coordinates of each individual over time

--- a/R/get_spatially_discretized_trajectories.R
+++ b/R/get_spatially_discretized_trajectories.R
@@ -3,8 +3,11 @@
 #' @description
 #' `r lifecycle::badge("experimental")`
 #'
-#' Gets spatially discretized trajectories from temporally discretized trajectories,
-#' using a certain "ruler length" R.
+#' Gets spatially discretized trajectories from temporally discretized trajectories
+#' by breaking down the trajectory into steps of minimum length `R`. 
+#'
+#' Starting with the first point, this function identifies the next point that is
+#' at least distance R away and drops any points between the two.
 #'
 #' TODO: Code doesn't deal well with strings of NAs within it - look into this.
 #'
@@ -17,18 +20,24 @@
 #' @param breaks vector of indexes to breaks in the data (e.g. breaks between days)
 #' @param verbose whether to print progress while running
 #'
-#' @returns Returns a list containing `spat_ts` (the time points associated with each point along the spatially discretized trajectory),
-#' `spat_xs` (the x coordinates of each point along the spatially discretized trajectory),
-#' `spat_ys` (the y coordinates of each point along the spatially discretized trajectory),
-#' `spat_breaks` (indexes to starts of breaks in the new spatially discretized data),
-#' `R` (radius used)
+#' @returns Returns a list containing
+#'  - `spat_ts` (`N x t_times*`) indices associated with each point along the spatially discretized trajectory
+#' - `spat_xs` (`N x n_times*`) the x coordinates of each point along the spatially discretized trajectory
+#' - `spat_ys` (`N x n_times*`) the y coordinates of each point along the spatially discretized trajectory
+#' - `spat_breaks` indexes to starts of breaks in the new spatially discretized data
+#'  If `breaks` is NULL, spat_breaks is an N x 1 matrix of 1s.
+#' - `R` (radius used)
+#' where `n_times*` is the max (accross individuals) number of datapoints after filtering. (`n_times*` is less than or equal to `n_times``).
 #' @export
 get_spatially_discretized_trajectories <- function(xs, ys, R, breaks = NULL, verbose = T){
+  checkmate::assert_matrix(xs, mode = 'numeric')
+  checkmate::assert_matrix(ys, mode = 'numeric', nrows = nrow(xs), ncol=ncol(xs))
+  checkmate::assert_number(R, lower=0)
+  checkmate::check_integerish(
+    breaks, lower=1, upper=ncol(xs), min.len = 1, max.len = ncol(xs), unique = TRUE, null.ok=TRUE
+  )
+  checkmate::check_flag(verbose)
 
-  #check matrix dimensions
-  if(nrow(xs) != nrow(ys) || ncol(xs) != ncol(ys)){
-    stop('xs and ys matrices must have same dimensions')
-  }
 
   #get dimensions
   n_inds <- nrow(xs)

--- a/inst/tinytest/test-get_spatially_discretized_trajectories.R
+++ b/inst/tinytest/test-get_spatially_discretized_trajectories.R
@@ -1,0 +1,106 @@
+x <- c(0, .9, 1.1, 2.2, 2.5)
+y <- rep(0, length(x))
+
+spat_t <- c(1, 3, 4)
+spat_x <- c(0, 1.1, 2.2)
+spat_y <- rep(0, length(spat_x))
+
+if(FALSE) expect_equivalent(
+  get_spatially_discretized_trajectories(rbind(x), rbind(y), 1, verbose = F),
+  list(
+    spat_ts = rbind(spat_t),
+    spat_xs = rbind(spat_x),
+    spat_ys = rbind(spat_y),
+    spat_breaks = rbind(1),
+    R = 1
+  ),
+  info = 'basic functionality: one individual'
+)
+
+expect_equivalent(
+  get_spatially_discretized_trajectories(rbind(x, x), rbind(y,y), 1, verbose = F),
+  list(
+    spat_ts = rbind(spat_t, spat_t),
+    spat_xs = rbind(spat_x, spat_x),
+    spat_ys = rbind(spat_y, spat_y),
+    spat_breaks = rbind(1,1),
+    R = 1
+  ),
+  info = 'two identical individuals'
+)
+
+spat_t <- c(1, 2, 4)
+spat_x <- x[spat_t]
+spat_y <- y[spat_t]
+
+expect_equivalent(
+  get_spatially_discretized_trajectories(rbind(x, x), rbind(y, y), .5, verbose = F),
+  list(
+    spat_ts = rbind(spat_t, spat_t),
+    spat_xs = rbind(spat_x, spat_x),
+    spat_ys = rbind(spat_y, spat_y),
+    spat_breaks = rbind(1,1),
+    R = .5
+  ),
+  info = 'two identical individuals, R=.5'
+)
+
+x <- rbind(
+  c(0, 1.1, 2.2, 3.3),
+  c(0, .5, 1.1, 1.4)
+)
+y <- matrix(0, nrow(x), ncol(x))
+
+spat_t <- rbind(
+  c(1, 2, 3, 4),
+  c(1, 3, NA, NA)
+)
+spat_x <- rbind(
+  c(0, 1.1, 2.2, 3.3),
+  c(0, 1.1, NA, NA)
+)
+spat_y <- matrix(0, nrow(spat_x), ncol(spat_x))
+spat_y[is.na(spat_x)] <- NA
+
+expect_equivalent(
+  get_spatially_discretized_trajectories( x, y, 1, verbose = F),
+  list(
+    spat_ts = spat_t,
+    spat_xs = spat_x,
+    spat_ys = spat_y,
+    spat_breaks = rbind(1,1),
+    R = 1
+  ),
+  info = 'two individuals, different final length'
+)
+
+
+
+x <- rbind(
+  c(0, 1.1, 2.2, 3.3, 3.4, 4.5, 5.6),
+  c(0, .5, 1.1, 1.4, 0, 1.1, 2.2)
+)
+y <- matrix(0, nrow(x), ncol(x))
+
+spat_t <- rbind(
+  c(1, 2, 3, 4, 5, 6, 7),
+  c(1, 3, 5, 6, 7, NA, NA)
+)
+spat_x <- rbind(
+  c(0, 1.1, 2.2, 3.3, 3.4, 4.5, 5.6),
+  c(0, 1.1, 0, 1.1, 2.3, NA, NA)
+)
+spat_y <- matrix(0, nrow(spat_x), ncol(spat_x))
+spat_y[is.na(spat_x)] <- NA
+
+if(FALSE) expect_equivalent(
+  get_spatially_discretized_trajectories(x, y, 1, breaks=5, verbose = F),
+  list(
+    spat_ts = spat_t,
+    spat_xs = spat_x,
+    spat_ys = spat_y,
+    spat_breaks = rbind(5,3),
+    R = 1
+  ),
+  info = 'with breaks'
+)

--- a/inst/tinytest/test-get_spatially_discretized_trajectories.R
+++ b/inst/tinytest/test-get_spatially_discretized_trajectories.R
@@ -88,18 +88,18 @@ spat_t <- rbind(
 )
 spat_x <- rbind(
   c(0, 1.1, 2.2, 3.3, 3.4, 4.5, 5.6),
-  c(0, 1.1, 0, 1.1, 2.3, NA, NA)
+  c(0, 1.1, 0, 1.1, 2.2, NA, NA)
 )
 spat_y <- matrix(0, nrow(spat_x), ncol(spat_x))
 spat_y[is.na(spat_x)] <- NA
 
-if(FALSE) expect_equivalent(
+expect_equivalent(
   get_spatially_discretized_trajectories(x, y, 1, breaks=5, verbose = F),
   list(
     spat_ts = spat_t,
     spat_xs = spat_x,
     spat_ys = spat_y,
-    spat_breaks = rbind(5,3),
+    spat_breaks = rbind(c(1,5),c(1,3)),
     R = 1
   ),
   info = 'with breaks'


### PR DESCRIPTION
### Biggest Issue

With breaks, it seems like only the results from the last section is returned, not the whole trajectory.

### Design feedback

Putting the NAs at the end of the rows with fewer points makes these return matrices no longer one col=one timepoint. Since most the rest of your package makes this assumption, this seems a bit dangerous. Might make more sense to include full columns whenever any individual has a "used" timepoint there, and just put NA for those where the timepoint isn't used. This would of course make your final matrix longer/more sparse, but might help avoid confusion later.

### Other format issue

If xs, and ys are 1 by n_times matrices, then spat_xs, spat_ys are vectors, not 1 by n_times* matrices. This is inconsistent with other dimensions.